### PR TITLE
Check bincount in data coming from backend

### DIFF
--- a/qspectrumanalyzer/data.py
+++ b/qspectrumanalyzer/data.py
@@ -105,6 +105,10 @@ class DataStorage(QtCore.QObject):
 
     def update(self, data):
         """Update data storage"""
+        if self.y is not None and len(data["y"]) != len(self.y):
+          print("{:d} bins coming from backend, expected {:d}".format(len(data["y"]), len(self.y)))
+          return
+
         self.average_counter += 1
 
         if self.x is None:


### PR DESCRIPTION
The hackrf_sweep backend sometimes returns fewer data points than expected.
This leads to an error when trying to insert the data into the HistoryBuffer:

ValueError: cannot copy sequence with size 24750 to array axis with dimension 25000

Although the fundamental issue may lie within the backend, DataStorage should
avoid crashing in this case.