### PR TITLE
hackrf_sweep: Improve low frequency range capabilities

### DIFF
--- a/qspectrumanalyzer/backends/hackrf_sweep.py
+++ b/qspectrumanalyzer/backends/hackrf_sweep.py
@@ -1,4 +1,4 @@
-import subprocess, pprint, struct, shlex, time
+import subprocess, pprint, struct, shlex, sys, time
 
 import numpy as np
 from Qt import QtCore
@@ -143,10 +143,20 @@ class PowerThread(BasePowerThread):
         self.powerThreadStarted.emit()
 
         while self.alive:
-            buf = self.process.stdout.read(4)
+            try:
+                buf = self.process.stdout.read(4)
+            except AttributeError as e:
+                print(e, file=sys.stderr)
+                continue
+
             if buf:
                 (record_length,) = struct.unpack('I', buf)
-                buf = self.process.stdout.read(record_length)
+                try:
+                    buf = self.process.stdout.read(record_length)
+                except AttributeError as e:
+                    print(e, file=sys.stderr)
+                    continue
+
                 if buf:
                     self.parse_output(buf)
                 else:

--- a/qspectrumanalyzer/backends/hackrf_sweep.py
+++ b/qspectrumanalyzer/backends/hackrf_sweep.py
@@ -20,7 +20,7 @@ class Info(BaseInfo):
     stop_freq_min = 0
     stop_freq_max = 7250
     stop_freq = 6000
-    bin_size_min = 40
+    bin_size_min = 3
     bin_size_max = 5000
     bin_size = 1000
     interval = 0
@@ -38,10 +38,11 @@ class PowerThread(BasePowerThread):
               interval=0.0, gain=40, ppm=0, crop=0, single_shot=False,
               device=0, sample_rate=20000000, bandwidth=0, lnb_lo=0):
         """Setup hackrf_sweep params"""
-        # theoretically we can support bins smaller than 40 kHz, but it is
-        # unlikely to result in acceptable performance
-        if bin_size < 40:
-            bin_size = 40
+        # Small bin sizes (<40 kHz) are only suitable with an arbitrarily
+        # reduced sweep interval. Bin sizes smaller than 3 kHz showed to be
+        # infeasible also in these cases.
+        if bin_size < 3:
+            bin_size = 3
         if bin_size > 5000:
             bin_size = 5000
 


### PR DESCRIPTION
These changes allow observing narrow frequency ranges in higher resolution using the hackrf_sweep backend. The interval setting is used to arbitrarily limit the sweep interval. Commits should be self-explanatory.
![bildschirmfoto von 2017-03-24 21-40-54](https://cloud.githubusercontent.com/assets/11042539/24313046/967d6340-10db-11e7-811f-84708edb0911.png)
