### PR TITLE
Add option to modify number of samples used for averaging

### DIFF
--- a/qspectrumanalyzer/__main__.py
+++ b/qspectrumanalyzer/__main__.py
@@ -11,6 +11,7 @@ from qspectrumanalyzer.plot import SpectrumPlotWidget, WaterfallPlotWidget
 from qspectrumanalyzer.utils import str_to_color, human_time
 
 from qspectrumanalyzer.settings import QSpectrumAnalyzerSettings
+from qspectrumanalyzer.average import QSpectrumAnalyzerAverage
 from qspectrumanalyzer.smoothing import QSpectrumAnalyzerSmoothing
 from qspectrumanalyzer.persistence import QSpectrumAnalyzerPersistence
 from qspectrumanalyzer.colors import QSpectrumAnalyzerColors
@@ -443,6 +444,15 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
             self.data_storage.set_subtract_baseline(
                 bool(self.subtractBaselineCheckBox.isChecked()),
                 settings.value("baseline_file", None)
+            )
+
+    @QtCore.Slot()
+    def on_averageButton_clicked(self):
+        dialog = QSpectrumAnalyzerAverage(self)
+        if dialog.exec_():
+            settings = QtCore.QSettings()
+            self.data_storage.set_average(
+                settings.value("average_samples", 0, int)
             )
 
     @QtCore.Slot()

--- a/qspectrumanalyzer/average.py
+++ b/qspectrumanalyzer/average.py
@@ -1,0 +1,21 @@
+from Qt import QtCore, QtWidgets
+
+from qspectrumanalyzer.ui_qspectrumanalyzer_average import Ui_QSpectrumAnalyzerAverage
+
+
+class QSpectrumAnalyzerAverage(QtWidgets.QDialog, Ui_QSpectrumAnalyzerAverage):
+    """QSpectrumAnalyzer spectrum smoothing dialog"""
+    def __init__(self, parent=None):
+        # Initialize UI
+        super().__init__(parent)
+        self.setupUi(self)
+
+        # Load settings
+        settings = QtCore.QSettings()
+        self.averageSamplesSpinBox.setValue(settings.value("average_samples", 0, int))
+
+    def accept(self):
+        """Save settings when dialog is accepted"""
+        settings = QtCore.QSettings()
+        settings.setValue("average_samples", self.averageSamplesSpinBox.value())
+        QtWidgets.QDialog.accept(self)

--- a/qspectrumanalyzer/data.py
+++ b/qspectrumanalyzer/data.py
@@ -77,6 +77,7 @@ class DataStorage(QtCore.QObject):
         self.prev_baseline = None
         self.baseline = None
         self.baseline_x = None
+        self.average_samples = 0
 
         # Use only one worker thread because it is not faster
         # with more threads (and memory consumption is much higher)
@@ -154,7 +155,8 @@ class DataStorage(QtCore.QObject):
         if self.average is None:
             self.average = data["y"].copy()
         else:
-            self.average = np.average((self.average, data["y"]), axis=0, weights=(self.average_counter - 1, 1))
+            weight = self.average_samples if self.average_samples > 0 else self.average_counter - 1
+            self.average = np.average((self.average, data["y"]), axis=0, weights=(weight, 1))
             self.average_updated.emit(self)
 
     def update_peak_hold_max(self, data):
@@ -176,6 +178,10 @@ class DataStorage(QtCore.QObject):
     def smooth_data(self, y):
         """Apply smoothing function to data"""
         return smooth(y, window_len=self.smooth_length, window=self.smooth_window)
+
+    def set_average(self, average=0):
+        """Set average params"""
+        self.average_samples = average
 
     def set_smooth(self, toggle, length=11, window="hanning"):
         """Toggle smoothing and set smoothing params"""

--- a/qspectrumanalyzer/qspectrumanalyzer.ui
+++ b/qspectrumanalyzer/qspectrumanalyzer.ui
@@ -52,7 +52,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>32</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -522,6 +522,13 @@
       <widget class="QCheckBox" name="subtractBaselineCheckBox">
        <property name="text">
         <string>Subtract baseline</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QToolButton" name="averageButton">
+       <property name="text">
+        <string>...</string>
        </property>
       </widget>
      </item>

--- a/qspectrumanalyzer/qspectrumanalyzer_average.ui
+++ b/qspectrumanalyzer/qspectrumanalyzer_average.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QSpectrumAnalyzerAverage</class>
+ <widget class="QDialog" name="QSpectrumAnalyzerAverage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>530</width>
+    <height>130</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Average - QSpectrumAnalyzer</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Number of samples:</string>
+       </property>
+       <property name="buddy">
+        <cstring>averageSamplesSpinBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="averageSamplesSpinBox">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>5000</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>1</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>averageSamplesSpinBox</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QSpectrumAnalyzerAverage</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>218</x>
+     <y>104</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QSpectrumAnalyzerAverage</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>218</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>224</x>
+     <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/qspectrumanalyzer/ui_qspectrumanalyzer.py
+++ b/qspectrumanalyzer/ui_qspectrumanalyzer.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'qspectrumanalyzer/qspectrumanalyzer.ui'
 #
-# Created by: PyQt5 UI code generator 5.8
+# Created by: PyQt5 UI code generator 5.9
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -41,7 +41,7 @@ class Ui_QSpectrumAnalyzerMainWindow(object):
         self.horizontalLayout.addWidget(self.plotSplitter)
         QSpectrumAnalyzerMainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(QSpectrumAnalyzerMainWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 1200, 32))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 1200, 22))
         self.menubar.setObjectName("menubar")
         self.menu_File = QtWidgets.QMenu(self.menubar)
         self.menu_File.setObjectName("menu_File")
@@ -240,6 +240,9 @@ class Ui_QSpectrumAnalyzerMainWindow(object):
         self.subtractBaselineCheckBox = QtWidgets.QCheckBox(self.settingsDockWidgetContents)
         self.subtractBaselineCheckBox.setObjectName("subtractBaselineCheckBox")
         self.gridLayout.addWidget(self.subtractBaselineCheckBox, 10, 0, 1, 1)
+        self.averageButton = QtWidgets.QToolButton(self.settingsDockWidgetContents)
+        self.averageButton.setObjectName("averageButton")
+        self.gridLayout.addWidget(self.averageButton, 6, 2, 1, 1)
         self.settingsDockWidget.setWidget(self.settingsDockWidgetContents)
         QSpectrumAnalyzerMainWindow.addDockWidget(QtCore.Qt.DockWidgetArea(2), self.settingsDockWidget)
         self.levelsDockWidget = QtWidgets.QDockWidget(QSpectrumAnalyzerMainWindow)
@@ -346,6 +349,7 @@ class Ui_QSpectrumAnalyzerMainWindow(object):
         self.baselineCheckBox.setText(_translate("QSpectrumAnalyzerMainWindow", "Baseline"))
         self.baselineButton.setText(_translate("QSpectrumAnalyzerMainWindow", "..."))
         self.subtractBaselineCheckBox.setText(_translate("QSpectrumAnalyzerMainWindow", "Subtract baseline"))
+        self.averageButton.setText(_translate("QSpectrumAnalyzerMainWindow", "..."))
         self.levelsDockWidget.setWindowTitle(_translate("QSpectrumAnalyzerMainWindow", "Levels"))
         self.action_Settings.setText(_translate("QSpectrumAnalyzerMainWindow", "&Settings..."))
         self.action_Quit.setText(_translate("QSpectrumAnalyzerMainWindow", "&Quit"))

--- a/qspectrumanalyzer/ui_qspectrumanalyzer_average.py
+++ b/qspectrumanalyzer/ui_qspectrumanalyzer_average.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'qspectrumanalyzer/qspectrumanalyzer_average.ui'
+#
+# Created by: PyQt5 UI code generator 5.9
+#
+# WARNING! All changes made in this file will be lost!
+
+from Qt import QtCore, QtGui, QtWidgets
+
+class Ui_QSpectrumAnalyzerAverage(object):
+    def setupUi(self, QSpectrumAnalyzerAverage):
+        QSpectrumAnalyzerAverage.setObjectName("QSpectrumAnalyzerAverage")
+        QSpectrumAnalyzerAverage.resize(530, 130)
+        self.verticalLayout = QtWidgets.QVBoxLayout(QSpectrumAnalyzerAverage)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.formLayout = QtWidgets.QFormLayout()
+        self.formLayout.setObjectName("formLayout")
+        self.label = QtWidgets.QLabel(QSpectrumAnalyzerAverage)
+        self.label.setObjectName("label")
+        self.formLayout.setWidget(0, QtWidgets.QFormLayout.LabelRole, self.label)
+        self.averageSamplesSpinBox = QtWidgets.QSpinBox(QSpectrumAnalyzerAverage)
+        self.averageSamplesSpinBox.setMinimum(0)
+        self.averageSamplesSpinBox.setMaximum(5000)
+        self.averageSamplesSpinBox.setProperty("value", 0)
+        self.averageSamplesSpinBox.setObjectName("averageSamplesSpinBox")
+        self.formLayout.setWidget(0, QtWidgets.QFormLayout.FieldRole, self.averageSamplesSpinBox)
+        self.verticalLayout.addLayout(self.formLayout)
+        spacerItem = QtWidgets.QSpacerItem(20, 1, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+        self.buttonBox = QtWidgets.QDialogButtonBox(QSpectrumAnalyzerAverage)
+        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Cancel|QtWidgets.QDialogButtonBox.Ok)
+        self.buttonBox.setObjectName("buttonBox")
+        self.verticalLayout.addWidget(self.buttonBox)
+        self.label.setBuddy(self.averageSamplesSpinBox)
+
+        self.retranslateUi(QSpectrumAnalyzerAverage)
+        self.buttonBox.accepted.connect(QSpectrumAnalyzerAverage.accept)
+        self.buttonBox.rejected.connect(QSpectrumAnalyzerAverage.reject)
+        QtCore.QMetaObject.connectSlotsByName(QSpectrumAnalyzerAverage)
+        QSpectrumAnalyzerAverage.setTabOrder(self.averageSamplesSpinBox, self.buttonBox)
+
+    def retranslateUi(self, QSpectrumAnalyzerAverage):
+        _translate = QtCore.QCoreApplication.translate
+        QSpectrumAnalyzerAverage.setWindowTitle(_translate("QSpectrumAnalyzerAverage", "Average - QSpectrumAnalyzer"))
+        self.label.setText(_translate("QSpectrumAnalyzerAverage", "Number of samples:"))
+


### PR DESCRIPTION
As it was, average was always performed using all samples from the start of scan.

Adding an option to modify the number of samples taken for averaging, allowing moving average for transient signals.