### PR TITLE
Error in Progress bar (types)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 dist/
 MANIFEST
 *.egg-info
+*#*#*
+.#*

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Ubuntu:
 *******
 ::
 
-    # Add SoapySDR PPA to your system
+    # Add SoapySDR PPA to your system (pre 22.04, now in repositories)
     sudo add-apt-repository -y ppa:myriadrf/drivers
 
     # Update list of packages

--- a/qspectrumanalyzer/__main__.py
+++ b/qspectrumanalyzer/__main__.py
@@ -263,9 +263,10 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
 
     def update_progress(self, value):
         """Update progress bar"""
-        value *= 1000
+        # progress bar needs all values in int
+        value = int(value * 1000) #resolution is thousandths
         value_max = int(self.intervalSpinBox.value() * 1000)
-
+        
         if value_max < 1000:
             return
 

--- a/qspectrumanalyzer/__main__.py
+++ b/qspectrumanalyzer/__main__.py
@@ -264,7 +264,7 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
     def update_progress(self, value):
         """Update progress bar"""
         value *= 1000
-        value_max = self.intervalSpinBox.value() * 1000
+        value_max = int(self.intervalSpinBox.value() * 1000)
 
         if value_max < 1000:
             return
@@ -300,7 +300,7 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
         self.start_timestamp = self.prev_data_timestamp
 
         if self.intervalSpinBox.value() >= 1:
-            self.progressbar.setRange(0, self.intervalSpinBox.value() * 1000)
+            self.progressbar.setRange(0, int(self.intervalSpinBox.value() * 1000))
         else:
             self.progressbar.setRange(0, 0)
         self.update_progress(0)


### PR DESCRIPTION
Kubuntu 22.04, Python 3.11.6
Gives error
 File "XXXX/qspectrumanalyzer/__main__.py", line 280, in update_progress
    self.progressbar.setValue(value)
TypeError: setValue(self, value: int): argument 1 has unexpected type 'float'

Suggested documentation change and fixing types in progress bar method.