### PR TITLE
Hackrf sweep fix for a deprecated num py function

### DIFF
--- a/qspectrumanalyzer/backends/hackrf_sweep.py
+++ b/qspectrumanalyzer/backends/hackrf_sweep.py
@@ -115,7 +115,7 @@ class PowerThread(BasePowerThread):
     def parse_output(self, buf):
         """Parse one buf of output from hackrf_sweep"""
         (low_edge, high_edge) = struct.unpack('QQ', buf[:16])
-        data = np.fromstring(buf[16:], dtype='<f4')
+        data = np.frombuffer(buf[16:], dtype='<f4')
         step = (high_edge - low_edge) / len(data)
 
         if (low_edge // 1000000) <= (self.params["start_freq"] - self.lnb_lo / 1e6):

--- a/qspectrumanalyzer/plot.py
+++ b/qspectrumanalyzer/plot.py
@@ -311,7 +311,7 @@ class WaterfallPlotWidget:
         # Create waterfall image on first run
         if self.counter == 1:
             self.waterfallImg = pg.ImageItem()
-            self.waterfallImg.scale()
+            self.waterfallImg.scale((data_storage.x[-1] - data_storage.x[0]) / len(data_storage.x), 1)
             self.plot.clear()
             self.plot.addItem(self.waterfallImg)
 

--- a/qspectrumanalyzer/plot.py
+++ b/qspectrumanalyzer/plot.py
@@ -311,7 +311,7 @@ class WaterfallPlotWidget:
         # Create waterfall image on first run
         if self.counter == 1:
             self.waterfallImg = pg.ImageItem()
-            self.waterfallImg.scale((data_storage.x[-1] - data_storage.x[0]) / len(data_storage.x), 1)
+            self.waterfallImg.scale()
             self.plot.clear()
             self.plot.addItem(self.waterfallImg)
 


### PR DESCRIPTION
There is an error caused by a deprecated NumPy function in the QSpectrumAnalyzer code. The np.fromstring() method with binary data has been removed in newer NumPy versions. This patch fixes it.